### PR TITLE
Add Playwright helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ If you prefer to build Nanobrowser yourself, follow these steps:
    pnpm dev
    ```
 
+## 🧪 Run with Playwright
+
+Use Playwright to drive a browser session with Nanobrowser loaded:
+
+1. Install the helpers:
+   ```bash
+   npm install patchright playwright
+   ```
+2. Run the helper script:
+   ```bash
+   node run-nanobrowser.js
+   ```
+
+This launches Playwright's patched Chromium with the built extension loaded so you can automate pages programmatically.
+
 ## 🤖 Choosing Your Models
 
 Nanobrowser allows you to configure different LLM models for each agent to balance performance and cost. Here are recommended configurations:

--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
     "typescript": "5.5.4",
     "turbo": "^2.5.3",
     "vite": "6.3.5",
-    "run-script-os": "^1.1.6"
+    "run-script-os": "^1.1.6",
+    "patchright": "^1.52.5",
+    "playwright": "^1.53.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json}": [

--- a/run-nanobrowser.js
+++ b/run-nanobrowser.js
@@ -1,0 +1,43 @@
+import path from 'path';
+import { patchPlaywright } from 'patchright';
+import { chromium } from 'playwright';
+
+async function main() {
+  // 1) Stealth-patch Playwright’s Chromium install
+  await patchPlaywright({
+    browser: 'chromium',
+    // omit `patches` for the full suite, or list specific ones:
+    // patches: [require('patchright/lib/patches/hide-webdriver'), ...]
+  });
+
+  // 2) Point to your local nanobrowser extension folder
+  const extensionPath = path.resolve('./nanobrowser');
+
+  // 3) Launch a persistent context with ONLY nanobrowser loaded
+  const context = await chromium.launchPersistentContext('', {
+    headless: false,     // set to true if you don’t need the UI
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+      '--start-maximized',
+    ],
+  });
+
+  // 4) Open the tab where nanobrowser shows up
+  const pages = context.pages();
+  const page  = pages.length ? pages[0] : await context.newPage();
+
+  // 5) Navigate somewhere and let Nanobrowser do its thing
+  await page.goto('https://twitter.com');
+
+  // OPTIONAL: interact via Playwright
+  // e.g. click Nanobrowser’s docked sidebar toggle
+  // await page.click('css=[data-nanobrowser-toggle]');
+
+  console.log('✅ Nanobrowser is running in a stealth-patched Playwright session.');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- create `run-nanobrowser.js` helper to launch a patched Playwright session with the extension
- document how to use it in the README
- include `patchright` and `playwright` as dev dependencies

## Testing
- `pnpm lint` *(fails: Unsupported Node version)*

------
https://chatgpt.com/codex/tasks/task_e_6868b9a52af883238995cc9c76e7cf44